### PR TITLE
Conflict resolution

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
 
 [testenv:isort]
 commands =
-    isort -rc  setup.py pypinot tests
+    isort setup.py pypinot tests --check-only -m=VERTICAL_HANGING_INDENT --line-length=88 --trailing-comma
 deps =
  isort
 


### PR DESCRIPTION
There are some problems:
- You used `isort -rc ...` that it was for old version. So, tox ran `isort` on all codes.

- There was a conflict between black and isort.  I handle it.